### PR TITLE
Add docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=frontend-builder /usr/src/app/dist /go/src/app/frontend/dist
 
 RUN go get -u github.com/gobuffalo/packr/packr && \
     packr && \
-    go build github.com/relvacode/storm/cmd/storm
+    go build -ldflags="-s -w" github.com/relvacode/storm/cmd/storm
 
 
 FROM alpine

--- a/README.md
+++ b/README.md
@@ -36,7 +36,23 @@ The recommended way to run Storm is with a Docker image.
 You'll need a Deluge container running with a valid [auth configuration](https://dev.deluge-torrent.org/wiki/UserGuide/Authentication). 
 Storm needs a way to contact the Deluge RPC daemon so it's best that you create a [Docker network](https://docs.docker.com/engine/tutorials/networkingcontainers/) and attach the Storm container to that network.
 
-Then you can use `DELUGE_RPC_HOSTNAME=deluge_container_name` with `DELUGE_RPC_USERNAME` and `DELUGE_RPC_PASSWORD` from your Deluge auth file.
+Once that's setup you'll need to configure Deluge to allow remote RPC connections:
+
+Open up `core.conf` in your Deluge configuration folder and set
+
+```
+"allow_remote": true
+```
+
+Then you can use the following environment variables to configure Storm
+
+| Environment | Description |
+| ----------- | ----------- |
+| `DELUGE_RPC_HOSTNAME` | The Deluge RPC hostname |
+| `DELUGE_RPC_USERNAME` | The username from Deluge auth |
+| `DELUGE_RPC_PASSWORD` | The password from Deluge auth |
+| `DELUGE_RPC_VERSION` | `v1` or `v2` depending on your Deluge version |
+
 
 __Important__
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2.1"
+
+services:
+  deluge:
+    image: ghcr.io/linuxserver/deluge
+    volumes:
+      - deluge-config:/config
+      - ./core.conf:/config/core.conf
+  storm:
+    build: .
+    environment:
+      DELUGE_RPC_VERSION: v2
+      DELUGE_RPC_HOSTNAME: deluge
+      DELUGE_RPC_USERNAME: localclient
+      DELUGE_RPC_PASSWORD: 707228f42b81e12377e943271f8c05b796545cd2
+    ports:
+      - 8221:8221
+
+volumes:
+  deluge-config:


### PR DESCRIPTION
Adds an example `docker-compose.yml`. Also strips debug flags from Go compile, and enumerates useful options in README