### PR TITLE
Sticky menubar

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,5 +1,8 @@
 .p-menubar {
   padding: .5rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 
   & button.t-menu-button:not(:first-child) {
     margin-left: 6px;


### PR DESCRIPTION
Makes the menubar stick to the top while scrolling down, as requested in https://github.com/relvacode/storm/issues/34


![Screen Recording 2022-12-04 at 20 52 39](https://user-images.githubusercontent.com/18260178/205512466-4818196c-948d-4f77-bfac-702d8b9167c2.gif)


Browser support:

<img width="1446" alt="image" src="https://user-images.githubusercontent.com/18260178/205511625-27a1ab94-7d33-4d0d-81ab-c9a23bc6715f.png">

Unfortunately I can't test it as I'm not sure how to compile this, but I've previewed the CSS in Chrome's devtools and it works perfectly.

Thanks!